### PR TITLE
feat: add tech-staff as codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# CODEOWNERS: https://help.github.com/articles/about-codeowners/
+
+# Primary repo maintainers.
+*                   @gnolang/tech-staff


### PR DESCRIPTION
Add Gnolang tech staff as the code owners for this repo