### PR TITLE
fix: formatting use outdated source

### DIFF
--- a/internal/lsp/format.go
+++ b/internal/lsp/format.go
@@ -3,6 +3,7 @@ package lsp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"math"
 
@@ -19,8 +20,12 @@ func (s *server) Formatting(ctx context.Context, reply jsonrpc2.Replier, req jso
 	}
 
 	uri := params.TextDocument.URI
+	file, ok := s.snapshot.Get(uri.Filename())
+	if !ok {
+		return replyErr(ctx, reply, fmt.Errorf("snapshot %s not found", uri.Filename()))
+	}
 
-	formatted, err := tools.Format(uri.Filename())
+	formatted, err := tools.Format(file.Src)
 	if err != nil {
 		return replyErr(ctx, reply, err)
 	}

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -47,6 +47,7 @@ func BuildServerHandler(conn jsonrpc2.Conn, e *env.Env) jsonrpc2.Handler {
 }
 
 func (s *server) ServerHandler(ctx context.Context, reply jsonrpc2.Replier, req jsonrpc2.Request) error {
+	slog.Info("handle", "method", req.Method())
 	if req.Method() == protocol.MethodInitialize {
 		err := s.Initialize(ctx, reply, req)
 		if err != nil {

--- a/internal/tools/format.go
+++ b/internal/tools/format.go
@@ -3,18 +3,30 @@ package tools
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
-func Format(file string) ([]byte, error) {
-	cmd := exec.Command("gno", "fmt", file)
+func Format(source []byte) ([]byte, error) {
+	// gno fmt accepts only files, so we need to write source in a temp file.
+	tmpDir, err := os.MkdirTemp("", "gnopls-fmt")
+	if err != nil {
+		return nil, fmt.Errorf("format: %w", err)
+	}
+	tmpFile := filepath.Join(tmpDir, "file.gno")
+	err = os.WriteFile(tmpFile, source, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("format: %w", err)
+	}
+	defer os.Remove(tmpDir)
+	cmd := exec.Command("gno", "fmt", tmpFile)
 	var stdin, stderr bytes.Buffer
 	cmd.Stdout = &stdin
 	cmd.Stderr = &stderr
-	err := cmd.Run()
-	if err != nil {
-		return nil, fmt.Errorf("running '%s': %w: %s", strings.Join(cmd.Args, " "), err, stderr.String())
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("format: running '%s': %w: %s", strings.Join(cmd.Args, " "), err, stderr.String())
 	}
 	return stdin.Bytes(), nil
 }


### PR DESCRIPTION
Instead of using the filename as the input of `gno fmt`, which is by definition outdated since the save has not happened yet, we take the content of the file from the snapshots (updated by didChange/didSave) and write a temporary file with so we can pass it to `gno fmt`.